### PR TITLE
PotRemoteBoard update remote pin instances on local write operations

### DIFF
--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testConnectionWithExistingState.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testConnectionWithExistingState.st
@@ -1,0 +1,12 @@
+tests
+testConnectionWithExistingState
+	[:device :connector |
+		board connectors: { connector }.
+		board devices: { device }.
+		
+		board connectWithExistingState.
+	
+		[driver connectToBoard.
+		device connect] should beDoneInOrder.
+		connector should not receive recoverState.
+	] runWithMocks

--- a/src/PharoThings-Hardware-Core.package/PotBoard.class/class/startUp..st
+++ b/src/PharoThings-Hardware-Core.package/PotBoard.class/class/startUp..st
@@ -1,4 +1,10 @@
 system startup
 startUp: isImageStarting
 	current ifNil: [ ^self ].
-	current connect
+	isImageStarting 
+		ifTrue: [ current connect]
+		ifFalse: [ 
+			"In case of simple image save we do not recover configured board pin state
+			because it would affect manually modified pins state 
+			which is not desired when user saves the image"
+			current connectWithExistingState ]

--- a/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/connectWithExistingState.st
+++ b/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/connectWithExistingState.st
@@ -1,0 +1,5 @@
+controlling
+connectWithExistingState
+
+	self connectDriver.
+	devices do: [ :each | each connect ]

--- a/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeDigitalValue.into..st
+++ b/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeDigitalValue.into..st
@@ -1,0 +1,4 @@
+operations
+writeDigitalValue: aBit into: aPin
+
+	self writeValue: aBit into: aPin

--- a/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writePWMValue.into..st
+++ b/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writePWMValue.into..st
@@ -1,0 +1,4 @@
+operations
+writePWMValue: aNumber into: aPin
+
+	self writeValue: aNumber into: aPin

--- a/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeValue.into..st
+++ b/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeValue.into..st
@@ -1,0 +1,6 @@
+operations
+writeValue: aNumber into: aPin
+
+	| remotePin |
+	remotePin := proxy findPinLike: aPin.
+	remotePin value: aNumber


### PR DESCRIPTION
PotRemoteBoard update remote pin instances on local write operations.
It fix problem when local pin and remote pin were desynchronazed