### PR TITLE
Better pin accessing API of the board and better header printing

### DIFF
--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardConnectorTests.class/instance/testGettingPinAtHeaderNumber.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardConnectorTests.class/instance/testGettingPinAtHeaderNumber.st
@@ -7,5 +7,5 @@ testGettingPinAtHeaderNumber
 	pin3 := PotGPIO id: 30.
 	connector pins: {  pin1. pin2. pin3 }.
 	
-	(connector pinAtHeader: 2) should be: pin2.
-	(connector pinAtHeader: 3) should be: pin3
+	(connector pinAtHeaderNumber: 2) should be: pin2.
+	(connector pinAtHeaderNumber: 3) should be: pin3

--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinAtHeaderNumber.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinAtHeaderNumber.st
@@ -1,0 +1,9 @@
+tests
+testFindPinAtHeaderNumber
+
+	| targetPin actual |
+	board addNewConnector: #TestConnectorId with: { 10 gpio. 12 gpio. targetPin := 14 gpio. 16 gpio}.
+	
+	actual := board pinAtHeader: 3 gpioHeader.
+	
+	actual should be: targetPin

--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinAtHeaderPosition.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinAtHeaderPosition.st
@@ -1,0 +1,9 @@
+tests
+testFindPinAtHeaderPosition
+
+	| targetPin actual |
+	board addNewConnector: #TestConnectorId with: { 10 gpio. 12 gpio. targetPin := 14 gpio. 16 gpio}.
+	
+	actual := board pinAtHeader: (2@1) gpioHeader.
+	
+	actual should be: targetPin

--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinById.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinById.st
@@ -1,0 +1,9 @@
+tests
+testFindPinById
+
+	| targetPin actual |
+	board addNewConnector: #TestConnectorId with: { 10 gpio. targetPin := 12 gpio. 14 gpio}.
+	
+	actual := board pinWithId: 12.
+	
+	actual should be: targetPin

--- a/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinLikeGivenOne.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotBoardTests.class/instance/testFindPinLikeGivenOne.st
@@ -1,0 +1,9 @@
+tests
+testFindPinLikeGivenOne
+
+	| targetPin actual |
+	board addNewConnector: #TestConnectorId with: { 10 gpio. targetPin := 12 gpio. 14 gpio}.
+	
+	actual := board pinLike: 12 gpio.
+	
+	actual should be: targetPin

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderNumber.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderNumber.st
@@ -1,0 +1,9 @@
+tests
+testCreationFromHeaderNumber
+	
+	| pinReference |
+	pinReference := 23 gpioHeader.
+	
+	pinReference should beInstanceOf: PotGPIOHeaderNumber.
+	pinReference value should equal: 23.
+	pinReference pointsToDefaultConnector should be: true

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderNumberAndConnectorName.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderNumberAndConnectorName.st
@@ -1,0 +1,9 @@
+tests
+testCreationFromHeaderNumberAndConnectorName
+	
+	| pinReference |
+	pinReference := 23 gpioHeader @ #P1.
+	
+	pinReference should beInstanceOf: PotGPIOHeaderNumber.
+	pinReference value should equal: 23.
+	pinReference connectorName should equal: #P1.

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderPosition.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testCreationFromHeaderPosition.st
@@ -1,0 +1,9 @@
+tests
+testCreationFromHeaderPosition
+	
+	| pinReference |
+	pinReference := (10@2) gpioHeader.
+	
+	pinReference should beInstanceOf: PotGPIOHeaderPosition.
+	pinReference row should equal: 10.
+	pinReference column should equal: 2

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderNumber.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderNumber.st
@@ -1,0 +1,7 @@
+tests
+testPrintingHeaderNumber
+	
+	| pinReference |
+	pinReference := 23 gpioHeader.
+	
+	pinReference printString should equal: '23 gpioHeader'

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderNumberWithNonDefaultConnector.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderNumberWithNonDefaultConnector.st
@@ -1,0 +1,7 @@
+tests
+testPrintingHeaderNumberWithNonDefaultConnector
+	
+	| pinReference |
+	pinReference := 23 gpioHeader @ #P1.
+	
+	pinReference printString should equal: '23 gpioHeader @ #P1'

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderPosition.st
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/instance/testPrintingHeaderPosition.st
@@ -1,0 +1,7 @@
+tests
+testPrintingHeaderPosition
+	
+	| pinReference |
+	pinReference := (3@2) gpioHeader.
+	
+	pinReference printString should equal: '(3@2) gpioHeader'

--- a/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/properties.json
+++ b/src/PharoThings-Hardware-Core-Tests.package/PotGPIOHeaderReferenceTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "PharoThings-Hardware-Core-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PotGPIOHeaderReferenceTests",
+	"type" : "normal"
+}

--- a/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/pinAtHeader..st
+++ b/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/pinAtHeader..st
@@ -1,0 +1,4 @@
+accessing
+pinAtHeader: aGPIOHeaderReference
+
+	^aGPIOHeaderReference correspondingPinIn: self

--- a/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/pinLike..st
+++ b/src/PharoThings-Hardware-Core.package/PotBoard.class/instance/pinLike..st
@@ -1,4 +1,4 @@
 accessing
-findPinLike: aPin
+pinLike: aPin
 
 	^self pinWithId: aPin id

--- a/src/PharoThings-Hardware-Core.package/PotBoardConnector.class/instance/pinAtHeaderNumber..st
+++ b/src/PharoThings-Hardware-Core.package/PotBoardConnector.class/instance/pinAtHeaderNumber..st
@@ -1,3 +1,3 @@
 accessing
-pinAtHeader: anInteger 
+pinAtHeaderNumber: anInteger 
 	^pins at: anInteger 

--- a/src/PharoThings-Hardware-Core.package/PotGPIOHeaderNumber.class/instance/correspondingPinInConnector..st
+++ b/src/PharoThings-Hardware-Core.package/PotGPIOHeaderNumber.class/instance/correspondingPinInConnector..st
@@ -1,4 +1,4 @@
 accessing
 correspondingPinInConnector: aBoardConnector
 
-	^aBoardConnector pinAtHeader: value
+	^aBoardConnector pinAtHeaderNumber: value

--- a/src/PharoThings-Hardware-Core.package/PotGPIOHeaderNumber.class/instance/printReferenceOn..st
+++ b/src/PharoThings-Hardware-Core.package/PotGPIOHeaderNumber.class/instance/printReferenceOn..st
@@ -1,0 +1,3 @@
+printing
+printReferenceOn: aStream
+	aStream print: value

--- a/src/PharoThings-Hardware-Core.package/PotGPIOHeaderPosition.class/instance/printReferenceOn..st
+++ b/src/PharoThings-Hardware-Core.package/PotGPIOHeaderPosition.class/instance/printReferenceOn..st
@@ -1,0 +1,3 @@
+printing
+printReferenceOn: aStream
+	aStream print: row @ column

--- a/src/PharoThings-Hardware-Core.package/PotGPIOHeaderReference.class/instance/printOn..st
+++ b/src/PharoThings-Hardware-Core.package/PotGPIOHeaderReference.class/instance/printOn..st
@@ -1,0 +1,10 @@
+printing
+printOn: aStream
+	self printReferenceOn: aStream.
+	aStream 
+		nextPut: $ ;
+		nextPutAll: #gpioHeader.
+	self pointsToDefaultConnector ifFalse: [ 
+		aStream 
+			nextPutAll: ' @ ' ;
+			print: connectorName ]

--- a/src/PharoThings-Hardware-Core.package/PotGPIOHeaderReference.class/instance/printReferenceOn..st
+++ b/src/PharoThings-Hardware-Core.package/PotGPIOHeaderReference.class/instance/printReferenceOn..st
@@ -1,0 +1,3 @@
+printing
+printReferenceOn: aStream
+	self subclassResponsibility 

--- a/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeValue.into..st
+++ b/src/PharoThings-RemoteToolsServer.package/PotRemoteBoard.class/instance/writeValue.into..st
@@ -2,5 +2,5 @@ operations
 writeValue: aNumber into: aPin
 
 	| remotePin |
-	remotePin := proxy findPinLike: aPin.
+	remotePin := proxy pinLike: aPin.
 	remotePin value: aNumber


### PR DESCRIPTION
Improves for pin accessing API of the board:
```Smalltalk
board pinLike: 17 gpio.
board pinWithId: 17.
board pinAtHeader: 12 gpioHeader.
board pinAtHeader: 2 gpioHeader @ #P5.
board pinAtHeader: (4@2) gpioHeader.
```
GPIO header references with better printing to be same as expression:
```Smalltalk
12 gpioHeader printString "==> '12 gpioHeader'"
```
It improves inspecting and debugging of configured but not installed devices