### PR TITLE
added welcome window with basic information and web links

### DIFF
--- a/src/BaselineOfPharoThings.package/CustomHelp.extension/class/codeSnippet..st
+++ b/src/BaselineOfPharoThings.package/CustomHelp.extension/class/codeSnippet..st
@@ -1,0 +1,6 @@
+*BaselineOfPharoThings
+codeSnippet: code
+	^	
+		String cr asText ,
+		code asText allBold , 
+		(self customLink: 'Open In Playground' block: [ GTPlayground openContents: code.])

--- a/src/BaselineOfPharoThings.package/CustomHelp.extension/class/customLink.block..st
+++ b/src/BaselineOfPharoThings.package/CustomHelp.extension/class/customLink.block..st
@@ -1,0 +1,8 @@
+*BaselineOfPharoThings
+customLink: aString block: clickBlock
+	aString ifEmpty: [ self errorEmptyString ].
+	
+	^ aString asText 
+		addAttribute: (	TextAction new actOnClickBlock: clickBlock);
+		addAttribute: (TextColor new color: self theme urlColor);
+		yourself

--- a/src/BaselineOfPharoThings.package/CustomHelp.extension/properties.json
+++ b/src/BaselineOfPharoThings.package/CustomHelp.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "CustomHelp"
+}

--- a/src/BaselineOfPharoThings.package/WelcomeHelp.extension/class/pages.st
+++ b/src/BaselineOfPharoThings.package/WelcomeHelp.extension/class/pages.st
@@ -1,0 +1,3 @@
+*BaselineOfPharoThings
+pages
+	^ #(pharoThings welcome changeLog learn exploreEnvironment useExternalPackages documentation gettingHelp)

--- a/src/BaselineOfPharoThings.package/WelcomeHelp.extension/class/pharoThings.st
+++ b/src/BaselineOfPharoThings.package/WelcomeHelp.extension/class/pharoThings.st
@@ -1,0 +1,77 @@
+*BaselineOfPharoThings
+pharoThings
+	^ HelpTopic 
+		title: 'PharoThings Quickstart guide'
+		contents: (self heading: 'PharoThings Quickstart guide'),
+
+'Welcome to Pharo, an immersive live programming environment.
+
+PharoThings is a live programming platform for IoT projects based on Pharo. 
+
+It includes:
+- Development tools to lively program, explore and debug remote boards (based on TelePharo)
+- Board modeling library which simplifies board configuration
+
+For more information, please visit here: ', (self url: 'https://github.com/pharo-iot/PharoThings'),
+
+(self subheading: 'Playing with PharoThings Booklet'), 
+'You can start playing with LEDs, sensors and learn how to build your Mini-Weather Station to shows the temperature and other parameters in an LCD display, and send the data to a cloud server.
+All this content and lessons are written in the PharoThings Booklet, you can access it here: ', (self url: 'https://github.com/SquareBracketAssociates/Booklet-APharoThingsTutorial'),
+
+(self subheading: 'Starting the server'), 
+'Option 1: Go to your remote device and start PharoThings by command line:
+pharo --headless Server.image  remotePharo --startServerOnPort=40423
+
+* Use --headless to OSX/ARM or --nodisplay to Linux
+
+', 
+'Option 2: Open Pharo UI in your remote device and start PharoThings in a playground:',
+(self codeSnippet: 'TlpRemoteUIManager registerOnPort: 40423.
+'),
+
+(self subheading: 'Connecting in PharoThings server by IP'), 
+(self codeSnippet: 'remotePharo := TlpRemoteIDE connectTo: (TCPAddress ip: #[127 0 0 1] port: 40423).
+'), 
+
+(self subheading: 'Connecting in PharoThings server by Hostname'), 
+(self codeSnippet: 'ip := NetNameResolver addressForName: ''pharothings-01''.
+remotePharo := TlpRemoteIDE connectTo: (TCPAddress ip: ip port: 40423).
+'), 
+
+(self subheading: 'Inspect the remote Raspberry Pi GPIO board'), 
+'If you dont receive any error, this means that you are connected. Now you can inspect the physical board of your Raspberry Pi:
+',
+(self codeSnippet: 'remoteBoard := remotePharo evaluate: [ RpiBoard3B current].
+remoteBoard inspect.
+'), 
+
+(self subheading: 'Working remotely'), 
+'You can also call the Remote Playground, Remote System Browser and Remote Process Browser:',
+(self codeSnippet: 'remotePharo openPlayground.
+remotePharo openBrowser.
+remotePharo openProcessBrowser.
+'), 
+
+(self subheading: 'Copy past code'), 
+(self codeSnippet: '"Connecting in PharoThings server by IP" 
+remotePharo := TlpRemoteIDE connectTo: (TCPAddress ip: #[127 0 0 1] port: 40423).
+
+"Connecting in PharoThings server by Hostname"
+ip := NetNameResolver addressForName: ''pharoiot-01''.
+remotePharo := TlpRemoteIDE connectTo: (TCPAddress ip: ip port: 40423).
+
+"Inspect remote board"
+remoteBoard := remotePharo evaluate: [ RpiBoard3B current ].
+remoteBoard inspect.
+
+"Open remote Playground, remote Browser and remote Process Browser"
+remotePharo openPlayground.
+remotePharo openBrowser.
+remotePharo openProcessBrowser.
+
+"Save the remote image"
+remotePharo saveImage.
+
+"Disconnect all remote sessions"
+TlpRemoteIDE disconnectAll.
+').

--- a/src/BaselineOfPharoThings.package/WelcomeHelp.extension/properties.json
+++ b/src/BaselineOfPharoThings.package/WelcomeHelp.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "WelcomeHelp"
+}


### PR DESCRIPTION
It is useful to have a welcome window with basic information and small examples about the project.Especially when images are automatically generated with the project and the user does not need to access GitHub or the project page.I think it is not necessary to create a package just for this, so I put it as an extension in the baseline package.